### PR TITLE
feat: give invis item frames enchantment glint for easier differentiability

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFrames.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFrames.java
@@ -95,6 +95,7 @@ public final class InvisibleItemFrames extends JavaPlugin {
         assert meta != null;
         meta.setDisplayName(config.getString("name"));
         meta.setLore(config.getStringList("lore"));
+        meta.setEnchantmentGlintOverride(true);
         meta.getPersistentDataContainer().set(IS_INVISIBLE_KEY, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
 

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFrames.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFrames.java
@@ -88,14 +88,14 @@ public final class InvisibleItemFrames extends JavaPlugin {
         // Plugin shutdown logic
     }
 
-    private ItemStack createItem(Material material, ConfigurationSection config) {
+    private ItemStack createItem(Material material, String name, List<String> lore, boolean enchantmentGlint) {
         ItemStack item = new ItemStack(material, 1);
 
         ItemMeta meta = item.getItemMeta();
         assert meta != null;
-        meta.setDisplayName(config.getString("name"));
-        meta.setLore(config.getStringList("lore"));
-        meta.setEnchantmentGlintOverride(true);
+        meta.setDisplayName(name);
+        meta.setLore(lore);
+        meta.setEnchantmentGlintOverride(enchantmentGlint ? true : null);
         meta.getPersistentDataContainer().set(IS_INVISIBLE_KEY, PersistentDataType.BYTE, (byte) 1);
         item.setItemMeta(meta);
 
@@ -141,20 +141,28 @@ public final class InvisibleItemFrames extends JavaPlugin {
         config.addDefault("items.invisible_glow_item_frame.name", ChatColor.RESET + "Invisible Glow Item Frame");
 
         config.addDefault("recipes.invisible_item_frame.count", 8);
+        config.addDefault("recipes.invisible_item_frame.glint", true);
         config.addDefault("recipes.invisible_item_frame.shape", Arrays.asList("FFF", "F F", "FFF"));
         config.addDefault("recipes.invisible_item_frame.ingredients.F", "minecraft:item_frame");
 
         config.addDefault("recipes.invisible_glow_item_frame.count", 8);
+        config.addDefault("recipes.invisible_item_frame.glint", true);
         config.addDefault("recipes.invisible_glow_item_frame.shape", Arrays.asList("FFF", "F F", "FFF"));
         config.addDefault("recipes.invisible_glow_item_frame.ingredients.F", "minecraft:glow_item_frame");
 
         ConfigurationSection regularItem = config.getConfigurationSection("items.invisible_item_frame");
         assert regularItem != null;
-        INVISIBLE_FRAME = createItem(Material.ITEM_FRAME, regularItem);
+        String rName = regularItem.getString("name");
+        List<String> rLore = regularItem.getStringList("lore");
+        boolean rEnchantmentGlint = regularItem.getBoolean("enchantment_glint");
+        INVISIBLE_FRAME = createItem(Material.ITEM_FRAME, rName, rLore, rEnchantmentGlint);
 
         ConfigurationSection glowItem = config.getConfigurationSection("items.invisible_glow_item_frame");
         assert glowItem != null;
-        INVISIBLE_GLOW_FRAME = createItem(Material.GLOW_ITEM_FRAME, glowItem);
+        String gName = glowItem.getString("name");
+        List<String> gLore = glowItem.getStringList("lore");
+        boolean gEnchantmentGlint = glowItem.getBoolean("enchantment_glint");
+        INVISIBLE_GLOW_FRAME = createItem(Material.GLOW_ITEM_FRAME, gName, gLore, gEnchantmentGlint);
 
         ConfigurationSection regularRecipe = config.getConfigurationSection("recipes.invisible_item_frame");
         assert regularRecipe != null;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -3,6 +3,8 @@ items:
   invisible_item_frame:
     # What the name of the item should be.
     name: §rInvisible Item Frame
+    # if the item should have an enchantment glint
+    enchantment_glint: true
 
     # Uncomment to assign lore text for the item.
     #lore:
@@ -11,6 +13,7 @@ items:
 
   invisible_glow_item_frame:
     name: §rInvisible Glow Item Frame
+    enchantment_glint: true
 
 # Customization for the crafting recipe.
 recipes:


### PR DESCRIPTION
makes it easier to tell apart reg item frames and invis ones.
- add config option, enabled by default
- remove antipattern: God Parameter Object in `createItem(...)`