### PR TITLE
streamline version detection

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -25,6 +25,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 public final class InvisibleItemFramesLite extends JavaPlugin {
     public static InvisibleItemFramesLite INSTANCE;
@@ -40,13 +41,16 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
     public void onEnable() {
         INSTANCE = this;
 
+        Version sv = getServerVersion();
+        getLogger().log(Level.INFO, "Detected server running on " + sv.minor + "," + sv.patch);
+
         // declare namespaced keys
         NamespacedKey isInvisibleKey = new NamespacedKey(this, "invisible");
         RECIPE_KEY = new NamespacedKey(this, "invisible_item_frame");
         GLOW_RECIPE_KEY = new NamespacedKey(this, "invisible_glow_item_frame");
 
         // get version specific item frame factory
-        frameFactory = ItemFrameFactoryProvider.get();
+        frameFactory = ItemFrameFactoryProvider.get(sv.minor, sv.patch);
 
         // register listeners
         PluginManager pm = this.getServer().getPluginManager();
@@ -139,4 +143,21 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
         assert glowRecipe != null;
         addRecipeFromConfig(GLOW_RECIPE_KEY, glowRecipe, INVISIBLE_GLOW_FRAME);
     }
+
+    private Version getServerVersion() {
+        String[] parts = Bukkit.getBukkitVersion().split("-")[0].split("\\.");
+        int minor = Integer.parseInt(parts[1]);
+        int patch = Integer.parseInt(parts[2]);
+        return new Version(minor, patch);
+    }
+
+    private static class Version {
+        final int minor, patch;
+
+        Version(int minor, int patch) {
+            this.minor = minor;
+            this.patch = patch;
+        }
+    }
+
 }

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/itemframe/ItemFrameFactoryProvider.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/itemframe/ItemFrameFactoryProvider.java
@@ -3,7 +3,6 @@ package com.atlasgong.invisibleitemframeslite.itemframe;
 import com.atlasgong.invisibleitemframeslite.itemframe.versions.ItemFrameFactory_1_16;
 import com.atlasgong.invisibleitemframeslite.itemframe.versions.ItemFrameFactory_1_17_Plus;
 import com.atlasgong.invisibleitemframeslite.itemframe.versions.ItemFrameFactory_1_20_R5_Plus;
-import org.bukkit.Bukkit;
 
 public class ItemFrameFactoryProvider {
 
@@ -11,19 +10,10 @@ public class ItemFrameFactoryProvider {
         throw new AssertionError("ItemFrameFactoryProvider should not be instantiated.");
     }
 
-    public static ItemFrameFactory get() {
-        String ver = Bukkit.getServer()
-                .getClass()
-                .getPackage()
-                .getName()
-                .split("\\.")[3]; // e.g. "v1_20_R2"
-        String[] p = ver.replace("v1_", "").split("_R");
-        int minor = Integer.parseInt(p[0]);
-        int patch = Integer.parseInt(p[1]);
-
-        if (minor == 16) {
+    public static ItemFrameFactory get(int minor, int patch) {
+        if (minor <= 16) {
             return new ItemFrameFactory_1_16();
-        } else if (minor >= 17 && (minor < 20 || patch < 5)) {
+        } else if (minor < 20 || (minor == 20 && patch < 5)) {
             return new ItemFrameFactory_1_17_Plus();
         } else {
             return new ItemFrameFactory_1_20_R5_Plus();


### PR DESCRIPTION
- extract version detection handling from `ItemFrameFactoryProvider` to main class
- create `Version` type (java 8 does not support records)
- fix conditional in `ItemFrameFactoryProvider` incorrectly catching versions like 1.20.4