### PR TITLE
refactor: add ItemFrameRegistry singleton and improve encapsulation

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -128,6 +128,8 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
 
         ShapelessRecipe recipe = new ShapelessRecipe(key, glowIs.clone());
         recipe.addIngredient(Utils.getNewMaterial("GLOW_INK_SAC", Material.INK_SAC));
+
+        //noinspection deprecation, undeprecated in 1.16.5
         recipe.addIngredient(new RecipeChoice.ExactChoice(regIs.clone()));
 
         Bukkit.addRecipe(recipe);

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -30,26 +30,33 @@ import java.util.Map;
 import java.util.logging.Level;
 
 public final class InvisibleItemFramesLite extends JavaPlugin {
+
     public static InvisibleItemFramesLite INSTANCE;
-    public static NamespacedKey RECIPE_KEY;
-    public static NamespacedKey GLOW_RECIPE_KEY;
-    public static NamespacedKey GLOW_SHAPELESS_RECIPE_KEY;
+    private static boolean firstLoad = true;
+
+    private final NamespacedKey IS_INVISIBLE_KEY;
+
+    private final NamespacedKey RECIPE_KEY;
+    private NamespacedKey GLOW_RECIPE_KEY;
+    private NamespacedKey GLOW_SHAPELESS_RECIPE_KEY;
+
     public static ItemStack INVISIBLE_FRAME;
     public static ItemStack INVISIBLE_GLOW_FRAME;
-    private static boolean firstLoad = true;
 
     private ItemFrameFactory frameFactory;
 
+    public InvisibleItemFramesLite() {
+        INSTANCE = this;
+        IS_INVISIBLE_KEY = new NamespacedKey(this, "invisible");
+        RECIPE_KEY = new NamespacedKey(this, "invisible_item_frame");
+    }
+
     @Override
     public void onEnable() {
-        INSTANCE = this;
-
         Version sv = getServerVersion();
         getLogger().log(Level.INFO, "Detected server running on " + sv.minor + "," + sv.patch);
 
-        // declare namespaced keys
-        NamespacedKey isInvisibleKey = new NamespacedKey(this, "invisible");
-        RECIPE_KEY = new NamespacedKey(this, "invisible_item_frame");
+        // declare namespaced keys for glow items
         if (sv.minor >= 17) {
             GLOW_RECIPE_KEY = new NamespacedKey(this, "invisible_glow_item_frame");
             GLOW_SHAPELESS_RECIPE_KEY = new NamespacedKey(this, "invisible_glow_item_frame_shapeless");
@@ -60,20 +67,19 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
 
         // register listeners
         PluginManager pm = this.getServer().getPluginManager();
-        pm.registerEvents(new ItemFramePlaceListener(isInvisibleKey), this);
-        pm.registerEvents(new ItemFrameBreakListener(isInvisibleKey), this);
-        pm.registerEvents(new ItemFrameInteractionListener(isInvisibleKey), this);
-        pm.registerEvents(new ItemFrameCraftListener(isInvisibleKey), this);
+        pm.registerEvents(new ItemFramePlaceListener(IS_INVISIBLE_KEY), this);
+        pm.registerEvents(new ItemFrameBreakListener(IS_INVISIBLE_KEY), this);
+        pm.registerEvents(new ItemFrameInteractionListener(IS_INVISIBLE_KEY), this);
+        pm.registerEvents(new ItemFrameCraftListener(IS_INVISIBLE_KEY), this);
 
         // load config and register recipes
         saveDefaultConfig();
-        loadConfig(isInvisibleKey);
+        loadConfig(IS_INVISIBLE_KEY);
 
         if (sv.minor >= 17) {
             // register shapeless glow item frame recipe
             registerShapelessGlowRecipe(GLOW_SHAPELESS_RECIPE_KEY);
         }
-
 
         firstLoad = false;
 
@@ -126,7 +132,7 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
         Bukkit.addRecipe(recipe);
     }
 
-    public void loadConfig(NamespacedKey isInvisibleKey) {
+    public void loadConfig(NamespacedKey IS_INVISIBLE_KEY) {
         final FileConfiguration config = getConfig();
 
         config.addDefault("items.invisible_item_frame.name", ChatColor.RESET + "Invisible Item Frame");
@@ -141,7 +147,7 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
         String rName = regularItem.getString("name");
         List<String> rLore = regularItem.getStringList("lore");
         boolean rEnchantmentGlint = regularItem.getBoolean("enchantment_glint");
-        INVISIBLE_FRAME = frameFactory.create(isInvisibleKey, rName, rLore, rEnchantmentGlint, false);
+        INVISIBLE_FRAME = frameFactory.create(IS_INVISIBLE_KEY, rName, rLore, rEnchantmentGlint, false);
 
         ConfigurationSection regularRecipe = config.getConfigurationSection("recipes.invisible_item_frame");
         assert regularRecipe != null;
@@ -161,7 +167,7 @@ public final class InvisibleItemFramesLite extends JavaPlugin {
             String gName = glowItem.getString("name");
             List<String> gLore = glowItem.getStringList("lore");
             boolean gEnchantmentGlint = glowItem.getBoolean("enchantment_glint");
-            INVISIBLE_GLOW_FRAME = frameFactory.create(isInvisibleKey, gName, gLore, gEnchantmentGlint, true);
+            INVISIBLE_GLOW_FRAME = frameFactory.create(IS_INVISIBLE_KEY, gName, gLore, gEnchantmentGlint, true);
 
             ConfigurationSection glowRecipe = config.getConfigurationSection("recipes.invisible_glow_item_frame");
             assert glowRecipe != null;

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/itemframe/ItemFrameRegistry.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/itemframe/ItemFrameRegistry.java
@@ -1,0 +1,103 @@
+package com.atlasgong.invisibleitemframeslite.itemframe;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+
+
+/**
+ * Singleton registry responsible for creating and storing custom invisible item frames
+ * using a version-specific {@link ItemFrameFactory}.
+ * <p>
+ * Call {@link #init(ItemFrameFactory)} once at plugin startup to initialize the registry.
+ * Access later using {@link #getInstance()}.
+ */
+public class ItemFrameRegistry {
+    private static ItemFrameRegistry instance;
+
+    private final ItemFrameFactory factory;
+    private ItemStack regInvisibleFrame;
+    private ItemStack glowInvisibleFrame;
+
+    /**
+     * Private constructor to enforce singleton pattern.
+     *
+     * @param factory the item frame factory used to generate item frames
+     */
+    private ItemFrameRegistry(ItemFrameFactory factory) {
+        this.factory = factory;
+    }
+
+    /**
+     * Initializes the singleton instance of the registry.
+     * Should be called only once, typically during plugin startup.
+     *
+     * @param factory the version-specific factory used to create item frames
+     * @throws IllegalStateException if the registry has already been initialized
+     */
+    public static void init(ItemFrameFactory factory) {
+        if (instance != null) {
+            throw new IllegalStateException("ItemFrameRegistry is already initialized.");
+        }
+        instance = new ItemFrameRegistry(factory);
+    }
+
+    /**
+     * Returns the singleton instance of the registry.
+     *
+     * @return the initialized {@link ItemFrameRegistry}
+     * @throws IllegalStateException if the registry has not been initialized yet
+     */
+    public static ItemFrameRegistry getInstance() {
+        if (instance == null) {
+            throw new IllegalStateException("ItemFrameRegistry not initialized. Call init() first.");
+        }
+        return instance;
+    }
+
+    /**
+     * Registers the regular (non-glowing) invisible item frame using the factory.
+     *
+     * @param isInvisibleKey   key used to mark the item frame as invisible
+     * @param name             display name of the item
+     * @param lore             lore lines for the item
+     * @param enchantmentGlint whether to apply an enchantment glint effect
+     */
+    public void registerRegularInvisibleItemFrame(NamespacedKey isInvisibleKey, String name, List<String> lore,
+                                                  boolean enchantmentGlint) {
+        regInvisibleFrame = factory.create(isInvisibleKey, name, lore, enchantmentGlint, false);
+    }
+
+    /**
+     * Registers the glowing invisible item frame using the factory.
+     *
+     * @param isInvisibleKey   key used to mark the item frame as invisible
+     * @param name             display name of the item
+     * @param lore             lore lines for the item
+     * @param enchantmentGlint whether to apply an enchantment glint effect
+     */
+    public void registerGlowInvisibleItemFrame(NamespacedKey isInvisibleKey, String name, List<String> lore,
+                                               boolean enchantmentGlint) {
+        glowInvisibleFrame = factory.create(isInvisibleKey, name, lore, enchantmentGlint, true);
+    }
+
+    /**
+     * Gets a clone of the registered regular invisible item frame.
+     *
+     * @return cloned {@link ItemStack} of the regular invisible item frame
+     */
+    public ItemStack getRegularInvisibleFrame() {
+        return regInvisibleFrame.clone();
+    }
+
+    /**
+     * Gets a clone of the registered glowing invisible item frame.
+     *
+     * @return cloned {@link ItemStack} of the glowing invisible item frame
+     */
+    public ItemStack getGlowInvisibleFrame() {
+        return glowInvisibleFrame.clone();
+    }
+
+}

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
@@ -4,8 +4,8 @@
 
 package com.atlasgong.invisibleitemframeslite.listeners;
 
-import com.atlasgong.invisibleitemframeslite.InvisibleItemFramesLite;
 import com.atlasgong.invisibleitemframeslite.Utils;
+import com.atlasgong.invisibleitemframeslite.itemframe.ItemFrameRegistry;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
@@ -16,6 +16,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * Listener that restores invisibility to item frame items when they are broken and dropped.
@@ -69,16 +70,28 @@ public class ItemFrameBreakListener implements Listener {
         final Item entity = event.getEntity();
         final ItemStack stack = entity.getItemStack();
         final long now = entity.getWorld().getFullTime();
+
         if (now != hangingBrokenAtTick) {
             return;
         }
+
+        ItemMeta regularInvisibleItemFrameMeta = ItemFrameRegistry
+                .getInstance()
+                .getRegularInvisibleFrame()
+                .getItemMeta();
+
+        ItemMeta glowInvisibleItemFrameMeta = ItemFrameRegistry
+                .getInstance()
+                .getGlowInvisibleFrame()
+                .getItemMeta();
+
         if (stack.getType() == Material.ITEM_FRAME) {
-            stack.setItemMeta(InvisibleItemFramesLite.INVISIBLE_FRAME.getItemMeta());
+            stack.setItemMeta(regularInvisibleItemFrameMeta);
         } else if (stack.getType().name().equals("GLOW_ITEM_FRAME")) {
             // use name based check to avoid referencing GLOW_ITEM_FRAME directly
             // which doesn't exist in versions before 1.17. this check will always fail
             // on pre-1.17 versions.
-            stack.setItemMeta(InvisibleItemFramesLite.INVISIBLE_GLOW_FRAME.getItemMeta());
+            stack.setItemMeta(glowInvisibleItemFrameMeta);
         } else {
             return;
         }

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameCraftListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameCraftListener.java
@@ -1,11 +1,8 @@
 package com.atlasgong.invisibleitemframeslite.listeners;
 
-import com.atlasgong.invisibleitemframeslite.InvisibleItemFramesLite;
 import com.atlasgong.invisibleitemframeslite.Utils;
-import org.bukkit.GameRule;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.PrepareItemCraftEvent;
@@ -52,14 +49,6 @@ public class ItemFrameCraftListener implements Listener {
                     return;
                 }
             }
-        }
-
-        // enforce doLimitedCrafting for players who haven’t unlocked the custom recipe.
-        final HumanEntity entity = event.getView().getPlayer();
-        final Boolean limitedCrafting = entity.getWorld().getGameRuleValue(GameRule.DO_LIMITED_CRAFTING);
-        final boolean entityHasRecipe = entity.hasDiscoveredRecipe(InvisibleItemFramesLite.RECIPE_KEY);
-        if (Boolean.TRUE.equals(limitedCrafting) && !entityHasRecipe) {
-            event.getInventory().setResult(new ItemStack(Material.AIR));
         }
     }
 }

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameInteractionListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameInteractionListener.java
@@ -74,7 +74,7 @@ public class ItemFrameInteractionListener implements Listener {
      * and invisible again when holding an item.
      */
     private static class ItemFrameUpdateRunnable extends BukkitRunnable {
-        ItemFrame itemFrame;
+        final ItemFrame itemFrame;
 
         ItemFrameUpdateRunnable(ItemFrame itemFrame) {
             this.itemFrame = itemFrame;


### PR DESCRIPTION
this PR addresses some concerns with encapsulation and management of custom items
- introduces a singleton registry `ItemFrameRegistry` to centralize and encapsulate the management of custom item frames, improving maintainability and reducing potential side effects from direct field access
- privatizes fields in the main plugin class and converts static fields for item frames and recipe keys to private/final fields or moves them into the registry
- replaces direct access to static item frame fields with getter methods from the registry throughout the codebase
- removes some redundant code in listeners (e.g., unnecessary checks in crafting)
- shifts recipe registration logic to use clones from the registry rather than static fields
- fields are marked final wherever possible