### PR TITLE
legal: remove redundant license disclaimers from source files

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 package com.atlasgong.invisibleitemframeslite;
 
 import com.atlasgong.invisibleitemframeslite.itemframe.ItemFrameFactory;

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
@@ -1,7 +1,3 @@
-/* This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
-
 package com.atlasgong.invisibleitemframeslite.listeners;
 
 import com.atlasgong.invisibleitemframeslite.Utils;


### PR DESCRIPTION
see Exhibit A of the [MPLv2](https://www.mozilla.org/en-US/MPL/2.0/)