### PR TITLE
refactor: config and recipe handling

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/ConfigurationManager.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/ConfigurationManager.java
@@ -1,0 +1,131 @@
+package com.atlasgong.invisibleitemframeslite;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapedRecipe;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class ConfigurationManager {
+
+    private final Logger logger;
+    private final FileConfiguration config;
+
+    public ConfigurationManager(Logger logger, FileConfiguration config) {
+        this.logger = logger;
+        this.config = config;
+    }
+
+    /**
+     * Adds default configuration values for a specific invisible item frame type.
+     *
+     * @param id   The identifier for the item type (e.g., "invisible_item_frame").
+     * @param type The {@link Material} for the frame (e.g. Material.ITEM_FRAME).
+     */
+    public void addConfigDefaults(String id, Material type) {
+        config.addDefault("items." + id + ".name", "Invisible " + Utils.toTitleCase(type.name().toLowerCase().replace("_", " ")));
+        config.addDefault("items." + id + ".enchantment_glint", true);
+        config.addDefault("recipes." + id + ".count", 8);
+        config.addDefault("recipes." + id + ".shape", Arrays.asList("FFF", "FAF", "FFF"));
+        config.addDefault("recipes." + id + ".ingredients.F", "minecraft:" + type.name().toLowerCase());
+        config.addDefault("recipes." + id + ".ingredients.A", "minecraft:phantom_membrane");
+    }
+
+    /**
+     * Loads frame data from a given configuration section, deserializing text using MiniMessage.
+     * The client code is expected to call `addConfigDefaults()` before this function.
+     *
+     * @param itemId The item ID for the corresponding configuration section.
+     * @return An {@link ItemFrameData} object containing the name, lore, and glint flag.
+     */
+    public ItemFrameData loadItemData(String itemId) {
+        ConfigurationSection section = config.getConfigurationSection("items." + itemId);
+        if (section == null) {
+            throw new IllegalArgumentException("Missing configuration section for 'items." + itemId + "'.");
+        }
+
+        // get name, lore, and glint from config
+        String name = section.getString("name");
+        assert name != null;
+        List<String> lore = section.getStringList("lore");
+        boolean glint = section.getBoolean("enchantment_glint");
+
+        // translate strings to components
+
+        // get legacy component serializer for legacy config
+        LegacyComponentSerializer lcs = LegacyComponentSerializer.legacy('§');
+
+        Component nameComponent;
+        if (name.contains("§")) { // if string incl legacy characters
+            nameComponent = lcs.deserialize(name);
+        } else {
+            nameComponent = MiniMessage.miniMessage().deserialize(name);
+        }
+
+        List<Component> loreComponents = lore.stream()
+                .map(line -> {
+                    if (line.contains("§")) {
+                        return lcs.deserialize(line);
+                    }
+                    return MiniMessage.miniMessage().deserialize(line);
+                })
+                .toList();
+
+        return new ItemFrameData(nameComponent, loreComponents, glint);
+    }
+
+    /**
+     * Loads a Bukkit recipe from a given configuration section.
+     * The client code is expected to call `addConfigDefaults()` before this function.
+     *
+     * @param recipeKey The unique namespaced key identifier for the recipe.
+     * @param itemId    The item ID for the corresponding configuration section.
+     * @param result    The item the recipe is expected to craft.
+     */
+    public Recipe loadRecipe(NamespacedKey recipeKey, String itemId, ItemStack result) {
+        ConfigurationSection section = config.getConfigurationSection("recipes." + itemId);
+        if (section == null) {
+            throw new IllegalArgumentException("Missing configuration section for 'recipes." + itemId + "'.");
+        }
+
+        ItemStack item = result.clone();
+        int count = section.getInt("count");
+        if (count == 0) {
+            logger.severe("Recipe count of " + itemId + " is 0. Falling back to 1.");
+            count = 1;
+        }
+        item.setAmount(count);
+        ShapedRecipe recipe = new ShapedRecipe(recipeKey, item);
+        List<String> shape = section.getStringList("shape");
+        if (shape.isEmpty()) {
+            logger.severe("Recipe shape is empty. Cannot continue.");
+            return null;
+        }
+        recipe.shape(shape.toArray(new String[0]));
+
+        ConfigurationSection ingredients = section.getConfigurationSection("ingredients");
+        // if this is null, then the defaults above are incorrect.
+        assert ingredients != null;
+        for (Map.Entry<String, Object> entry : ingredients.getValues(false).entrySet()) {
+            Material material = Material.matchMaterial(entry.getValue().toString());
+            if (material == null) {
+                logger.severe("Failed to find material '" + entry.getValue().toString() + "'. Skipping it and " +
+                        "continuing.");
+                continue;
+            }
+            recipe.setIngredient(entry.getKey().charAt(0), material);
+        }
+
+        return recipe;
+    }
+}

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -4,24 +4,15 @@ import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameBreakListener;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameCraftListener;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameInteractionListener;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFramePlaceListener;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.minimessage.MiniMessage;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice;
-import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 public class InvisibleItemFramesLite extends JavaPlugin {
 
@@ -58,6 +49,8 @@ public class InvisibleItemFramesLite extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        firstLoad = false;
+
         // register listeners
         PluginManager pm = this.getServer().getPluginManager();
         pm.registerEvents(new ItemFramePlaceListener(IS_INVISIBLE_KEY), this);
@@ -65,50 +58,52 @@ public class InvisibleItemFramesLite extends JavaPlugin {
         pm.registerEvents(new ItemFrameInteractionListener(this, IS_INVISIBLE_KEY), this);
         pm.registerEvents(new ItemFrameCraftListener(IS_INVISIBLE_KEY), this);
 
-        // load config and register recipes
+        // load config
         saveDefaultConfig();
-        loadConfig(IS_INVISIBLE_KEY);
+        ConfigurationManager cm = new ConfigurationManager(getLogger(), getConfig());
+        cm.addConfigDefaults("invisible_item_frame", Material.ITEM_FRAME);
+        cm.addConfigDefaults("invisible_glow_item_frame", Material.GLOW_ITEM_FRAME);
+
+        // register item frames with the registry
+        ItemFrameRegistry registry = ItemFrameRegistry.getInstance();
+        ItemFrameData regData = cm.loadItemData("invisible_item_frame");
+        ItemFrameData glowData = cm.loadItemData("invisible_glow_item_frame");
+        registry.registerRegularInvisibleItemFrame(getInvisibleKey(), regData.name(),
+                regData.lore(), regData.glint());
+        registry.registerGlowInvisibleItemFrame(getInvisibleKey(), glowData.name(),
+                glowData.lore(), glowData.glint());
+
+        // register recipes
+        Recipe regRecipe = cm.loadRecipe(getRegularRecipeKey(), "invisible_item_frame",
+                registry.getRegularInvisibleFrame());
+        registerRecipe(regRecipe);
+
+        Recipe glowRecipe = cm.loadRecipe(getGlowRecipeKey(), "invisible_glow_item_frame",
+                registry.getGlowInvisibleFrame());
+        registerRecipe(glowRecipe);
 
         // register shapeless glow item frame recipe
-        registerShapelessGlowRecipe(SHAPELESS_GLOW_RECIPE_KEY);
-
-        firstLoad = false;
+        registerShapelessGlowRecipe(getShapelessGlowRecipeKey());
 
         // incl metrics for bStats
         int pluginId = 25837;
         @SuppressWarnings("unused") Metrics metrics = new Metrics(this, pluginId);
     }
 
-    private void addRecipeFromConfig(NamespacedKey key, ConfigurationSection config, ItemStack item) {
-        item = item.clone();
-        item.setAmount(config.getInt("count"));
-        ShapedRecipe recipe = new ShapedRecipe(key, item);
-        List<String> shape = config.getStringList("shape");
-        recipe.shape(shape.toArray(new String[0]));
-
-        ConfigurationSection ingredients = config.getConfigurationSection("ingredients");
-        // If this is null, then the defaults above are incorrect.
-        assert ingredients != null;
-        for (Map.Entry<String, Object> entry : ingredients.getValues(false).entrySet()) {
-            Material material = Material.matchMaterial(entry.getValue().toString());
-            if (material == null) {
-                getLogger()
-                        .severe("Failed to find material " + entry.getValue().toString() + ", recipe might not work.");
-                continue;
-            }
-            recipe.setIngredient(entry.getKey().charAt(0), material);
-        }
-
+    private void registerRecipe(Recipe recipe) {
         try {
             Bukkit.addRecipe(recipe);
         } catch (IllegalStateException ignored) {
             if (firstLoad) {
-                getLogger().severe("Failed to add recipe " + config.getName() + ". This is likely an issue in the config");
+                getLogger().severe("Failed to add recipe. There is likely something wrong with the config. Try " +
+                        "deleting the config and restarting the server to regenerate the default config.");
             } else {
-                getLogger().warning("Failed to add recipe " + config.getName() + ", because Spigot doesn't support reloading recipes.");
+                getLogger().warning("A plugin reload was detected. Plugin reloads are not supported. Crafting recipes" +
+                        " failed to reload.");
             }
         }
     }
+
 
     /**
      * Adds a shapeless recipe to allow crafting an invisible item frame
@@ -128,113 +123,5 @@ public class InvisibleItemFramesLite extends JavaPlugin {
         Bukkit.addRecipe(recipe);
     }
 
-    /**
-     * Holds structured data for an invisible item frame including name, lore, and enchantment glint status.
-     *
-     * @param name  The display name as a MiniMessage Component.
-     * @param lore  The list of lore lines as MiniMessage Components.
-     * @param glint Whether the item has the enchantment glint effect.
-     */
-    private record ItemFrameData(Component name, List<Component> lore, boolean glint) {
-    }
-
-    /**
-     * Loads frame data from a given configuration section, deserializing text using MiniMessage.
-     * The client code is expected to call `addConfigDefaults()` before this function.
-     *
-     * @param section The configuration section containing the item's data.
-     * @return An {@link ItemFrameData} object containing the name, lore, and glint flag.
-     */
-    private ItemFrameData loadFrameData(ConfigurationSection section) {
-        // get name, lore, and glint from config
-        String name = section.getString("name");
-        assert name != null;
-        List<String> lore = section.getStringList("lore");
-        boolean glint = section.getBoolean("enchantment_glint");
-
-        // translate strings to components
-
-        // get legacy component serializer for legacy config
-        LegacyComponentSerializer lcs = LegacyComponentSerializer.legacy('§');
-
-        Component nameComponent;
-        if (name.contains("§")) { // if string incl legacy characters
-            nameComponent = lcs.deserialize(name);
-        } else {
-            nameComponent = MiniMessage.miniMessage().deserialize(name);
-        }
-
-        List<Component> loreComponents = lore.stream()
-                .map(line -> {
-                    if (line.contains("§")) {
-                        return lcs.deserialize(line);
-                    }
-                    return MiniMessage.miniMessage().deserialize(line);
-                })
-                .toList();
-
-        return new ItemFrameData(nameComponent, loreComponents, glint);
-    }
-
-    /**
-     * Adds default configuration values for a specific invisible item frame type.
-     *
-     * @param config The plugin's configuration file.
-     * @param id     The identifier for the item type (e.g., "invisible_item_frame").
-     * @param type   The {@link Material} for the frame (e.g. Material.ITEM_FRAME).
-     */
-    private void addConfigDefaults(FileConfiguration config, String id, Material type) {
-        config.addDefault("items." + id + ".name", "Invisible " + Utils.toTitleCase(type.name().replace("_", " ")));
-        config.addDefault("recipes." + id + ".count", 8);
-        config.addDefault("recipes." + id + ".glint", true);
-        config.addDefault("recipes." + id + ".shape", Arrays.asList("FFF", "FAF", "FFF"));
-        config.addDefault("recipes." + id + ".ingredients.F", "minecraft:" + type.name());
-        config.addDefault("recipes." + id + ".ingredients.A", "minecraft:phantom_membrane");
-    }
-
-
-    /**
-     * Loads configuration data for invisible item frames, registers them with the item frame registry, and registers
-     * their crafting recipes with the server.
-     *
-     * @param IS_INVISIBLE_KEY The key used for identifying invisible item frames.
-     */
-    public void loadConfig(NamespacedKey IS_INVISIBLE_KEY) {
-        final FileConfiguration config = getConfig();
-
-        // add default config values for both item frame types
-        addConfigDefaults(config, "invisible_item_frame", Material.ITEM_FRAME);
-        addConfigDefaults(config, "invisible_glow_item_frame", Material.GLOW_ITEM_FRAME);
-
-        // load and register regular invisible item frame
-        ConfigurationSection regularItem = config.getConfigurationSection("items.invisible_item_frame");
-        assert regularItem != null;
-        ItemFrameData regData = loadFrameData(regularItem);
-
-        // register frame with registry
-        ItemFrameRegistry.getInstance().registerRegularInvisibleItemFrame(
-                IS_INVISIBLE_KEY, regData.name(), regData.lore(), regData.glint()
-        );
-
-        // get and register the crafting recipe
-        ConfigurationSection regularRecipe = config.getConfigurationSection("recipes.invisible_item_frame");
-        assert regularRecipe != null;
-        addRecipeFromConfig(REGULAR_RECIPE_KEY, regularRecipe, ItemFrameRegistry.getInstance().getRegularInvisibleFrame());
-
-        // load and register glow invisible item frame
-        ConfigurationSection glowItem = config.getConfigurationSection("items.invisible_glow_item_frame");
-        assert glowItem != null;
-        ItemFrameData glowData = loadFrameData(glowItem);
-
-        // register frame with registry
-        ItemFrameRegistry.getInstance().registerGlowInvisibleItemFrame(
-                IS_INVISIBLE_KEY, glowData.name(), glowData.lore(), glowData.glint()
-        );
-
-        // get and register the crafting recipe
-        ConfigurationSection glowRecipe = config.getConfigurationSection("recipes.invisible_glow_item_frame");
-        assert glowRecipe != null;
-        addRecipeFromConfig(GLOW_RECIPE_KEY, glowRecipe, ItemFrameRegistry.getInstance().getGlowInvisibleFrame());
-    }
 
 }

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/ItemFrameData.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/ItemFrameData.java
@@ -1,0 +1,16 @@
+package com.atlasgong.invisibleitemframeslite;
+
+import net.kyori.adventure.text.Component;
+
+import java.util.List;
+
+/**
+ * Holds structured data for an invisible item frame including name, lore, and enchantment glint status.
+ *
+ * @param name  The display name as a MiniMessage Component.
+ * @param lore  The list of lore lines as MiniMessage Components.
+ * @param glint Whether the item has the enchantment glint effect.
+ */
+public record ItemFrameData(Component name, List<Component> lore, boolean glint) {
+
+}

--- a/src/test/java/com/atlasgong/invisibleitemframeslite/ConfigurationManagerTest.java
+++ b/src/test/java/com/atlasgong/invisibleitemframeslite/ConfigurationManagerTest.java
@@ -1,0 +1,288 @@
+package com.atlasgong.invisibleitemframeslite;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.Recipe;
+import org.bukkit.inventory.ShapedRecipe;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockbukkit.mockbukkit.MockBukkit;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ConfigurationManagerTest {
+
+    private InvisibleItemFramesLite plugin;
+    private Logger logger;
+
+    @BeforeEach
+    void setUp() {
+        MockBukkit.mock();
+        plugin = MockBukkit.load(InvisibleItemFramesLite.class);
+        logger = plugin.getLogger();
+    }
+
+    @AfterEach
+    void tearDown() {
+        MockBukkit.unmock();
+
+        // bypass singleton enforcement
+        try {
+            Field field = ItemFrameRegistry.class.getDeclaredField("instance");
+            field.setAccessible(true);
+            field.set(null, null);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invisible_item_frame", "invisible_glow_item_frame"})
+    void testAddConfigDefaults(String variant) {
+        Material type = Material.valueOf(variant.replaceFirst("invisible_", "").toUpperCase());
+
+        ConfigurationManager cm = new ConfigurationManager(logger, plugin.getConfig());
+        cm.addConfigDefaults(variant, type);
+
+        FileConfiguration config = plugin.getConfig();
+
+        assertEquals("§r" + Utils.toTitleCase(variant.replace('_', ' ')),
+                config.getString("items." + variant + ".name"));
+        assertTrue(config.getBoolean("items." + variant + ".enchantment_glint"));
+        assertEquals(8, config.getInt("recipes." + variant + ".count"));
+        assertEquals(Arrays.asList("FFF", "FAF", "FFF"), config.getStringList("recipes." + variant + ".shape"));
+        assertEquals("minecraft:" + type.name().toLowerCase(), config.getString("recipes." + variant + ".ingredients.F"));
+        assertEquals("minecraft:phantom_membrane",
+                config.getString("recipes." + variant + ".ingredients.A"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invisible_item_frame", "invisible_glow_item_frame"})
+    void testLoadItemData(String itemId) {
+        String name = Utils.toTitleCase(itemId.replace('_', ' '));
+
+        FileConfiguration config = plugin.getConfig();
+        config.set("items." + itemId + ".lore", Arrays.asList("<red>lorem ipsum</red>", "§llegacy ipsum")); // set lore
+
+        List<Component> lore = new ArrayList<>();
+        lore.add(MiniMessage.miniMessage().deserialize("<red>lorem ipsum</red>"));
+        lore.add(MiniMessage.miniMessage().deserialize("<bold>legacy ipsum</bold>"));
+
+        ItemFrameData ifd = new ItemFrameData(
+                MiniMessage.miniMessage().deserialize(name),
+                lore,
+                true
+        );
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        ItemFrameData actual = cm.loadItemData(itemId);
+
+        assertEquals(MiniMessage.miniMessage().serialize(ifd.name()),
+                MiniMessage.miniMessage().serialize(actual.name()), "name should be the same");
+
+        assertEquals(ifd.lore(), actual.lore(), "lore should be the same");
+
+        assertEquals(ifd.glint(), actual.glint(), "glint should be the same");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"invisible_item_frame", "invisible_glow_item_frame"})
+    void testLoadRecipe(String itemId) {
+        Material type = Material.valueOf(itemId.replaceFirst("invisible_", "").toUpperCase());
+
+        ConfigurationManager cm = new ConfigurationManager(logger, plugin.getConfig());
+        cm.addConfigDefaults(itemId, type);
+
+        NamespacedKey recipeKey = new NamespacedKey(plugin, itemId);
+        ItemStack result = new ItemStack(type);
+
+        Recipe recipe = cm.loadRecipe(recipeKey, itemId, result);
+
+        assertNotNull(recipe);
+        assertInstanceOf(ShapedRecipe.class, recipe);
+
+        ShapedRecipe shapedRecipe = (ShapedRecipe) recipe;
+        assertEquals(8, shapedRecipe.getResult().getAmount());
+        assertEquals(type, shapedRecipe.getResult().getType());
+    }
+
+    @Test
+    void testLoadItemData_missingConfigurationSection() {
+        ConfigurationManager cm = new ConfigurationManager(logger, plugin.getConfig());
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> cm.loadItemData("nonexistent_item"));
+
+        assertEquals("Missing configuration section for 'items.nonexistent_item'.", exception.getMessage());
+    }
+
+    @Test
+    void testLoadItemData_emptyLore() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("items.test_item.name", "Test Item");
+        config.set("items.test_item.lore", Collections.emptyList());
+        config.set("items.test_item.enchantment_glint", false);
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        ItemFrameData result = cm.loadItemData("test_item");
+
+        assertNotNull(result);
+        assertEquals("Test Item", MiniMessage.miniMessage().serialize(result.name()));
+        assertTrue(result.lore().isEmpty());
+        assertFalse(result.glint());
+    }
+
+    @Test
+    void testLoadItemData_mixedLegacyAndMiniMessage() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("items.test_item.name", "§6Gold Name");
+        config.set("items.test_item.lore", Arrays.asList("§clegacy red", "<green>minimsg green</green>"));
+        config.set("items.test_item.enchantment_glint", true);
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        ItemFrameData result = cm.loadItemData("test_item");
+
+        assertNotNull(result);
+        assertEquals(2, result.lore().size());
+        assertTrue(result.glint());
+    }
+
+    @Test
+    void testLoadItemData_onlyMiniMessage() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("items.test_item.name", "<bold><blue>minimsg name</blue></bold>");
+        config.set("items.test_item.lore", Arrays.asList("<red>red line</red>", "<italic>italic line</italic>"));
+        config.set("items.test_item.enchantment_glint", false);
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        ItemFrameData result = cm.loadItemData("test_item");
+
+        assertNotNull(result);
+        assertEquals("<bold><blue>minimsg name", MiniMessage.miniMessage().serialize(result.name()));
+        assertEquals(2, result.lore().size());
+        assertFalse(result.glint());
+    }
+
+    @Test
+    void testLoadRecipe_missingConfigurationSection() {
+        ConfigurationManager cm = new ConfigurationManager(logger, plugin.getConfig());
+        NamespacedKey recipeKey = new NamespacedKey(plugin, "test_recipe");
+        ItemStack result = new ItemStack(Material.ITEM_FRAME);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> cm.loadRecipe(recipeKey, "nonexistent_recipe", result));
+
+        assertEquals("Missing configuration section for 'recipes.nonexistent_recipe'.", exception.getMessage());
+    }
+
+    @Test
+    void testLoadRecipe_zeroCount() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("recipes.test_recipe.count", 0);
+        config.set("recipes.test_recipe.shape", Arrays.asList("FFF", "FAF", "FFF"));
+        config.set("recipes.test_recipe.ingredients.F", "minecraft:item_frame");
+        config.set("recipes.test_recipe.ingredients.A", "minecraft:phantom_membrane");
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        NamespacedKey recipeKey = new NamespacedKey(plugin, "test_recipe");
+        ItemStack result = new ItemStack(Material.ITEM_FRAME);
+
+        Recipe recipe = cm.loadRecipe(recipeKey, "test_recipe", result);
+
+        assertNotNull(recipe);
+        assertInstanceOf(ShapedRecipe.class, recipe);
+        ShapedRecipe shapedRecipe = (ShapedRecipe) recipe;
+        assertEquals(1, shapedRecipe.getResult().getAmount()); // should fallback to 1
+    }
+
+    @Test
+    void testLoadRecipe_invalidMaterial() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("recipes.test_recipe.count", 4);
+        config.set("recipes.test_recipe.shape", Arrays.asList("FFF", "FAF", "FFF"));
+        config.set("recipes.test_recipe.ingredients.F", "minecraft:invalid_material");
+        config.set("recipes.test_recipe.ingredients.A", "minecraft:phantom_membrane");
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        NamespacedKey recipeKey = new NamespacedKey(plugin, "test_recipe");
+        ItemStack result = new ItemStack(Material.ITEM_FRAME);
+
+        Recipe recipe = cm.loadRecipe(recipeKey, "test_recipe", result);
+
+        assertNotNull(recipe);
+        assertInstanceOf(ShapedRecipe.class, recipe);
+        // recipe should still be created, but invalid material should be skipped
+    }
+
+    @Test
+    void testLoadRecipe_customCount() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("recipes.test_recipe.count", 16);
+        config.set("recipes.test_recipe.shape", Arrays.asList("FFF", "FAF", "FFF"));
+        config.set("recipes.test_recipe.ingredients.F", "minecraft:item_frame");
+        config.set("recipes.test_recipe.ingredients.A", "minecraft:phantom_membrane");
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        NamespacedKey recipeKey = new NamespacedKey(plugin, "test_recipe");
+        ItemStack result = new ItemStack(Material.ITEM_FRAME);
+
+        Recipe recipe = cm.loadRecipe(recipeKey, "test_recipe", result);
+
+        assertNotNull(recipe);
+        assertInstanceOf(ShapedRecipe.class, recipe);
+        ShapedRecipe shapedRecipe = (ShapedRecipe) recipe;
+        assertEquals(16, shapedRecipe.getResult().getAmount());
+    }
+
+    @Test
+    void testAddConfigDefaults_overwriteExisting() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("items.test_item.name", "Existing Name");
+        config.set("items.test_item.enchantment_glint", false);
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        cm.addConfigDefaults("test_item", Material.ITEM_FRAME);
+
+        // addDefault should not overwrite existing values
+        assertEquals("Existing Name", config.getString("items.test_item.name"));
+        assertFalse(config.getBoolean("items.test_item.enchantment_glint"));
+
+        // but should add missing defaults
+        assertEquals(8, config.getInt("recipes.test_item.count"));
+    }
+
+    @Test
+    void testLoadRecipe_emptyShape() {
+        FileConfiguration config = plugin.getConfig();
+        config.set("recipes.test_recipe.count", 1);
+        config.set("recipes.test_recipe.shape", Collections.emptyList());
+        config.set("recipes.test_recipe.ingredients.F", "minecraft:item_frame");
+
+        ConfigurationManager cm = new ConfigurationManager(logger, config);
+        NamespacedKey recipeKey = new NamespacedKey(plugin, "test_recipe");
+        ItemStack result = new ItemStack(Material.ITEM_FRAME);
+
+        Recipe recipe = cm.loadRecipe(recipeKey, "test_recipe", result);
+
+        assertNull(recipe);
+    }
+}


### PR DESCRIPTION
this PR aims to decouple config logic and recipe loading from the main class, resolving the iceberg antipattern and prioritizing the SRP

# changes
  - removed inline config parsing and recipe creation logic from `InvisibleItemFramesLite`
  - moved inline `ItemFrameData` record to own file
  - added `ConfigurationManager` to handle:
      - setting default config values
      - loading item data (names, lore, glint flags)
      - building crafting recipes
  - simplified reload error handling with clear log messages
  - moved `ItemFrameData` record into its own class
  - added tests for `ConfigurationManager`