### PR TITLE
replace default config legacy formatting w minimsg

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,10 @@
+# Legacy chat formatting has been deprecated.
+# Please use Adventure's MiniMessage formatting: https://docs.advntr.dev/minimessage/format
+
 # configuration of item metadata
 items:
   invisible_item_frame:
-    name: §rInvisible Item Frame # what the name of the item should be
+    name: <!italic>Invisible Item Frame # what the name of the item should be
     enchantment_glint: true # if the item should have an enchantment glint
 
     # uncomment the below to assign lore text for the item
@@ -10,7 +13,7 @@ items:
     #  - line2
 
   invisible_glow_item_frame:
-    name: §rInvisible Glow Item Frame
+    name: <!italic>Invisible Glow Item Frame
     enchantment_glint: true
 
 # configuration for crafting recipes

--- a/src/test/java/com/atlasgong/invisibleitemframeslite/ConfigurationManagerTest.java
+++ b/src/test/java/com/atlasgong/invisibleitemframeslite/ConfigurationManagerTest.java
@@ -66,9 +66,11 @@ public class ConfigurationManagerTest {
         cm.addConfigDefaults(variant, type);
 
         FileConfiguration config = plugin.getConfig();
+        String itemName = config.getString("items." + variant + ".name");
+        assert itemName != null;
 
-        assertEquals("§r" + Utils.toTitleCase(variant.replace('_', ' ')),
-                config.getString("items." + variant + ".name"));
+        assertEquals(MiniMessage.miniMessage().deserialize("<!italic>" + Utils.toTitleCase(variant.replace('_', ' '))),
+                MiniMessage.miniMessage().deserialize(itemName));
         assertTrue(config.getBoolean("items." + variant + ".enchantment_glint"));
         assertEquals(8, config.getInt("recipes." + variant + ".count"));
         assertEquals(Arrays.asList("FFF", "FAF", "FFF"), config.getStringList("recipes." + variant + ".shape"));
@@ -98,7 +100,7 @@ public class ConfigurationManagerTest {
         ConfigurationManager cm = new ConfigurationManager(logger, config);
         ItemFrameData actual = cm.loadItemData(itemId);
 
-        assertEquals(MiniMessage.miniMessage().serialize(ifd.name()),
+        assertEquals("<!italic>" + MiniMessage.miniMessage().serialize(ifd.name()),
                 MiniMessage.miniMessage().serialize(actual.name()), "name should be the same");
 
         assertEquals(ifd.lore(), actual.lore(), "lore should be the same");


### PR DESCRIPTION
Server owners are expected to switch over to MiniMessage. I will drop legacy support when Paper drops it.