### PR TITLE
fix: item frame break handling to restore metadata via manual drop

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameBreakListener.java
@@ -2,30 +2,27 @@ package com.atlasgong.invisibleitemframeslite.listeners;
 
 import com.atlasgong.invisibleitemframeslite.ItemFrameRegistry;
 import com.atlasgong.invisibleitemframeslite.Utils;
-import org.bukkit.Material;
+import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Hanging;
-import org.bukkit.entity.Item;
+import org.bukkit.Sound;
+import org.bukkit.SoundCategory;
+import org.bukkit.World;
+import org.bukkit.entity.GlowItemFrame;
+import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.ItemSpawnEvent;
-import org.bukkit.event.hanging.HangingBreakByEntityEvent;
+import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
 /**
- * Listener that restores invisibility to item frame items when they are broken and dropped.
- * Spigot does not link item drops to the hanging entity directly, so this class tracks
- * the tick when an invisible item frame is broken and modifies the matching drop.
+ * Listener that ensures broken item frame items restore their {@link ItemMeta}
+ * when they are broken/dropped for any {@link org.bukkit.event.hanging.HangingBreakEvent.RemoveCause}.
  */
 public class ItemFrameBreakListener implements Listener {
 
     /** Key used to tag item frames as invisible via persistent data. */
     private final NamespacedKey isInvisibleKey;
-
-    /** World tick when an invisible item frame was last broken. Used to identify the drop. */
-    long hangingBrokenAtTick = -1;
 
     /**
      * Constructs a new ItemFrameBreakListener.
@@ -37,62 +34,60 @@ public class ItemFrameBreakListener implements Listener {
     }
 
     /**
-     * Records the current tick if an invisible item frame is broken.
-     * This allows tracking when the corresponding dropped item appears,
-     * since Spigot doesn't provide drop data in the break event.
+     * Paper doesn't provide drop data in the {@link HangingBreakEvent} event. This is problematic because we aren't
+     * able to set the metadata for the dropped item ({@link ItemMeta} does not transfer to its entity when its
+     * corresponding {@link ItemStack} is placed), and thus, an invisible item frame would drop as a regular one. To
+     * work around this, we cancel the event, manually remove the item entity, then manually drop the corresponding
+     * {@link ItemStack}.
      */
-    @EventHandler
-    public void onHangingBreak(HangingBreakByEntityEvent event) {
-        final Hanging entity = event.getEntity();
+    @EventHandler()
+    public void onHangingBreak(HangingBreakEvent e) {
+        final boolean isInvisFrame = Utils.isInvisibleItemFrame(e.getEntity(), isInvisibleKey);
+        if (!isInvisFrame) return;
 
-        final boolean isFrame = Utils.isInvisibleItemFrame(entity, isInvisibleKey);
-        Entity remover = event.getRemover();
-        if (remover == null) {
-            return;
+        final ItemFrame invisFrame = (ItemFrame) e.getEntity(); // safe to cast given check above
+        final Location loc = invisFrame.getLocation();
+
+        e.setCancelled(true);
+        invisFrame.remove();
+
+        // drop the item inside the frame if there was one
+        if (!invisFrame.getItem().getType().isAir()) {
+            dropItem(loc, invisFrame.getItem());
         }
 
-        if (isFrame) {
-            hangingBrokenAtTick = entity.getWorld().getFullTime();
+        // simulate item frame dropping
+        if (invisFrame instanceof GlowItemFrame) {
+            ItemStack glowInvisItemFrame = ItemFrameRegistry.getInstance().getGlowInvisibleFrame();
+            dropItem(loc, glowInvisItemFrame, Sound.ENTITY_GLOW_ITEM_FRAME_BREAK);
+        } else { // regular item frame
+            ItemStack regInvisItemFrame = ItemFrameRegistry.getInstance().getRegularInvisibleFrame();
+            dropItem(loc, regInvisItemFrame, Sound.ENTITY_ITEM_FRAME_BREAK);
         }
     }
 
     /**
-     * Detects when an item is spawned and checks if it’s the result of an invisible item frame breaking.
-     * If the tick matches the previously stored value, applies the correct invisible item frame metadata
-     * to preserve its invisibility after dropping.
+     * Simulates an item drop.
+     *
+     * @param loc        The location to naturally drop an item at.
+     * @param itemToDrop The item to be dropped.
+     * @param sound      The sound to be played.
      */
-    @EventHandler
-    public void onItemSpawn(ItemSpawnEvent event) {
-        final Item entity = event.getEntity();
-        final ItemStack stack = entity.getItemStack();
-        final long now = entity.getWorld().getFullTime();
+    private void dropItem(Location loc, ItemStack itemToDrop, Sound sound) {
+        World w = loc.getWorld();
+        w.dropItemNaturally(loc, itemToDrop);
+        if (sound != null) w.playSound(loc, sound, SoundCategory.BLOCKS, 1.0f, 1.0f);
+        // we do not need to adjust player stats, given the dropped item was from an entity and not a block
+    }
 
-        if (now != hangingBrokenAtTick) {
-            return;
-        }
-
-        ItemMeta regularInvisibleItemFrameMeta = ItemFrameRegistry
-                .getInstance()
-                .getRegularInvisibleFrame()
-                .getItemMeta();
-
-        ItemMeta glowInvisibleItemFrameMeta = ItemFrameRegistry
-                .getInstance()
-                .getGlowInvisibleFrame()
-                .getItemMeta();
-
-        if (stack.getType() == Material.ITEM_FRAME) {
-            stack.setItemMeta(regularInvisibleItemFrameMeta);
-        } else if (stack.getType().name().equals("GLOW_ITEM_FRAME")) {
-            // use name based check to avoid referencing GLOW_ITEM_FRAME directly
-            // which doesn't exist in versions before 1.17. this check will always fail
-            // on pre-1.17 versions.
-            stack.setItemMeta(glowInvisibleItemFrameMeta);
-        } else {
-            return;
-        }
-        hangingBrokenAtTick = -1;
-        entity.setItemStack(stack);
+    /**
+     * Simulates an item drop.
+     *
+     * @param loc        The location to naturally drop an item at.
+     * @param itemToDrop The item to be dropped.
+     */
+    private void dropItem(Location loc, ItemStack itemToDrop) {
+        dropItem(loc, itemToDrop, null);
     }
 
 }


### PR DESCRIPTION
This PR fixes the way broken invisible item frames are handled in order to correctly preserve their metadata (specifically `ItemMeta`) upon destruction. Instead of relying on tick recordings and `ItemSpawnEvent` to modify dropped entities after the fact, we now manually handle item drops at the point of frame break using `HangingBreakEvent`. It addresses and closes #34.

## Changes
- switched from `HangingBreakByEntityEvent` to `HangingBreakEvent`
    - the previous implementation relied on tracking the tick of entity breaks and modifying item spawns retroactively
    - the approach did not account for other `RemoveCause`s
    - the approach could fail if server TPS is not perfect
- now:
     - the break event is cancelled if the frame is identified as invisible
     - the invisible item frame entity is manually removed
     - the item held in the frame (if any) is dropped
     - the appropriate invisible item frame (glow or regular) is dropped manually using `World#dropItemNaturally`
         - the sound is simulated
         - this is handled by a new helper function `dropItem`