### PR TITLE
refactor: listeners to use modern paper event APIs and simplify logic

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -56,7 +56,7 @@ public class InvisibleItemFramesLite extends JavaPlugin {
         PluginManager pm = this.getServer().getPluginManager();
         pm.registerEvents(new ItemFramePlaceListener(IS_INVISIBLE_KEY), this);
         pm.registerEvents(new ItemFrameBreakListener(IS_INVISIBLE_KEY), this);
-        pm.registerEvents(new ItemFrameInteractionListener(this, IS_INVISIBLE_KEY), this);
+        pm.registerEvents(new ItemFrameInteractionListener(IS_INVISIBLE_KEY), this);
         pm.registerEvents(new ItemFrameCraftListener(IS_INVISIBLE_KEY), this);
 
         // load config

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameInteractionListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFrameInteractionListener.java
@@ -1,94 +1,38 @@
 package com.atlasgong.invisibleitemframeslite.listeners;
 
 import com.atlasgong.invisibleitemframeslite.Utils;
-import org.bukkit.Material;
+import io.papermc.paper.event.player.PlayerItemFrameChangeEvent;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.ItemFrame;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.player.PlayerInteractEntityEvent;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitRunnable;
 
-/**
- * Listener that handles interactions and damage events involving invisible item frames.
- * Ensures that the visibility of item frames is updated appropriately based on whether
- * they contain an item.
- */
+/** Listener that handles interactions with invisible item frames. */
 public class ItemFrameInteractionListener implements Listener {
-
-    private final JavaPlugin plugin;
 
     /** Key used to tag item frames as invisible via persistent data. */
     private final NamespacedKey isInvisibleKey;
 
-
     /**
      * Constructs a new ItemFrameInteractionListener.
      *
-     * @param plugin         The plugin instanced used for the Bukkit scheduler.
      * @param isInvisibleKey The {@link NamespacedKey} used to identify invisible item frames.
      */
-    public ItemFrameInteractionListener(JavaPlugin plugin, NamespacedKey isInvisibleKey) {
-        this.plugin = plugin;
+    public ItemFrameInteractionListener(NamespacedKey isInvisibleKey) {
         this.isInvisibleKey = isInvisibleKey;
     }
 
-
-    /**
-     * Triggered when a player right-clicks on an entity.
-     * If the entity is an invisible item frame, schedules a visibility update
-     * to reflect any item changes caused by the interaction (e.g., placing or removing an item).
-     */
+    /** Toggles visibility of invisible item frames s.t. they are visible when empty and invisible when filled. */
     @EventHandler
-    public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
-        final Entity entity = event.getRightClicked();
-        if (!Utils.isInvisibleItemFrame(entity, isInvisibleKey)) {
+    public void onItemFrameChange(PlayerItemFrameChangeEvent e) {
+        ItemFrame frame = e.getItemFrame();
+        if (!Utils.isInvisibleItemFrame(frame, isInvisibleKey)) {
             return;
         }
 
-        final ItemFrame frame = (ItemFrame) entity;
-        new ItemFrameUpdateRunnable(frame).runTask(plugin);
-    }
-
-
-    /**
-     * If the damaged entity is an invisible item frame, schedules a visibility update
-     * in case its item was removed (e.g. by a player punching it).
-     */
-    @EventHandler
-    public void onEntityDamageByEntityEvent(EntityDamageByEntityEvent event) {
-        final Entity entity = event.getEntity();
-        if (!Utils.isInvisibleItemFrame(entity, isInvisibleKey)) {
-            return;
-        }
-
-        final ItemFrame frame = (ItemFrame) entity;
-        new ItemFrameUpdateRunnable(frame).runTask(plugin);
-    }
-
-
-    /**
-     * A task that updates an invisible item frame’s visibility one tick later,
-     * ensuring that any changes to its contents (like items being added or removed)
-     * have already taken effect. Invisible item frames become visible when empty,
-     * and invisible again when holding an item.
-     */
-    private static class ItemFrameUpdateRunnable extends BukkitRunnable {
-        final ItemFrame itemFrame;
-
-        ItemFrameUpdateRunnable(ItemFrame itemFrame) {
-            this.itemFrame = itemFrame;
-        }
-
-        @Override
-        public void run() {
-            final ItemStack item = itemFrame.getItem();
-            final boolean hasItem = item.getType() != Material.AIR;
-            itemFrame.setVisible(!hasItem);
+        switch (e.getAction()) {
+            case PLACE -> frame.setVisible(false);
+            case REMOVE -> frame.setVisible(true);
         }
     }
 

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFramePlaceListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFramePlaceListener.java
@@ -1,34 +1,18 @@
 package com.atlasgong.invisibleitemframeslite.listeners;
 
 import com.atlasgong.invisibleitemframeslite.Utils;
-import org.bukkit.Location;
 import org.bukkit.NamespacedKey;
-import org.bukkit.block.Block;
-import org.bukkit.block.BlockFace;
-import org.bukkit.entity.ItemFrame;
-import org.bukkit.event.Event;
+import org.bukkit.entity.Hanging;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.hanging.HangingPlaceEvent;
-import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.persistence.PersistentDataType;
 
-/**
- * Listener class responsible for handling events related to placing invisible item frames.
- * When a player places an item frame tagged as "invisible", this class ensures that the
- * resulting entity is also marked as invisible using persistent data.
- */
+/** Listener that handles placement of invisible item frames. */
 public class ItemFramePlaceListener implements Listener {
 
     /** Key used to tag item frames as invisible via persistent data. */
     private final NamespacedKey isInvisibleKey;
-
-    /** The location where an invisible item frame is about to be placed. */
-    Location aboutToPlaceLocation = null;
-
-    /** The face of the block where the invisible item frame is about to be placed. */
-    BlockFace aboutToPlaceFace = null;
 
     /**
      * Constructs a new ItemFramePlaceListener.
@@ -45,39 +29,12 @@ public class ItemFramePlaceListener implements Listener {
      * item frame entity is tagged as invisible using persistent data.
      */
     @EventHandler
-    public void onHangingPlace(HangingPlaceEvent event) {
-        if (!(event.getEntity() instanceof ItemFrame)) return;
-        final Location loc = event.getBlock().getLocation();
-        final BlockFace face = event.getBlockFace();
-
-        if (loc.equals(aboutToPlaceLocation) && face == aboutToPlaceFace) {
-            aboutToPlaceLocation = null;
-            aboutToPlaceFace = null;
-            event.getEntity().getPersistentDataContainer().set(isInvisibleKey,
+    public void onHangingPlace(HangingPlaceEvent e) {
+        Hanging hanging = e.getEntity();
+        if (Utils.isInvisibleItemFrame(hanging, isInvisibleKey)) {
+            hanging.getPersistentDataContainer().set(isInvisibleKey,
                     PersistentDataType.BYTE, (byte) 1);
         }
     }
-
-    /**
-     * Handles the event triggered when a player interacts (right-clicks) to place an item.
-     * This method pre-records the intended location and face for the item frame placement
-     * if the item used is tagged as an invisible item frame.
-     * <p>
-     * Note: The {@link HangingPlaceEvent} does not contain information about which item was used,
-     * so this method is used to correlate item metadata with the entity placement.
-     */
-    @EventHandler
-    public void onPlayerInteract(PlayerInteractEvent event) {
-        final ItemStack item = event.getItem();
-
-        if (!Utils.isInvisibleItemFrame(item, isInvisibleKey) || event.useItemInHand() == Event.Result.DENY) {
-            return;
-        }
-
-        final Block block = event.getClickedBlock();
-        if (block != null) {
-            aboutToPlaceLocation = block.getRelative(event.getBlockFace()).getLocation();
-            aboutToPlaceFace = event.getBlockFace();
-        }
-    }
+    
 }

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFramePlaceListener.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/listeners/ItemFramePlaceListener.java
@@ -2,7 +2,6 @@ package com.atlasgong.invisibleitemframeslite.listeners;
 
 import com.atlasgong.invisibleitemframeslite.Utils;
 import org.bukkit.NamespacedKey;
-import org.bukkit.entity.Hanging;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.hanging.HangingPlaceEvent;
@@ -30,11 +29,10 @@ public class ItemFramePlaceListener implements Listener {
      */
     @EventHandler
     public void onHangingPlace(HangingPlaceEvent e) {
-        Hanging hanging = e.getEntity();
-        if (Utils.isInvisibleItemFrame(hanging, isInvisibleKey)) {
-            hanging.getPersistentDataContainer().set(isInvisibleKey,
+        if (Utils.isInvisibleItemFrame(e.getItemStack(), isInvisibleKey)) {
+            e.getEntity().getPersistentDataContainer().set(isInvisibleKey,
                     PersistentDataType.BYTE, (byte) 1);
         }
     }
-    
+
 }


### PR DESCRIPTION

## changes
- replaced `PlayerInteractEntityEvent` and `EntityDamageByEntityEvent` + `BukkitScheduler` combination with the modern `PlayerItemFrameChangeEvent` from paper (note, 1 step towards #43)
    - simplify placement detection logic by removing indirect tracking via player interaction and relying solely on persistent data tagging through direct API access
- simplify `ItemFramePlaceListener` by replacing `PlayerInteractEvent` with `HangingPlaceEvent`
    - removed complex tracking of location/face using `PlayerInteractEvent`
    - now directly checks if the placed `Hanging` is tagged as invisible
- removed asynchronous logic and dependency on `JavaPlugin`