### PR TITLE
fix(docs): remove explicit git clone url from contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,7 @@ Code is licensed under MPLv2, as per the original. See [LICENSE-MPL](./LICENSE-M
 - JDK 21
 - Maven
 
-1. Clone the repository:
-
-```
-git clone https://github.com/atlasgong/InvisibleItemFramesLite
-```
-
+1. Clone the repository
 2. Run, update, or write unit tests as necessary
 3. Build the project with Maven, test manually in-game
 4. Create a PR


### PR DESCRIPTION
not everyone uses https to clone, better to remove explicit link completely