### PR TITLE
fix: set dep adventure-text-serializer-legacy scope to provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.atlasgong</groupId>
     <artifactId>InvisibleItemFramesLite</artifactId>
-    <version>3.1.1</version>
+    <version>3.1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>InvisibleItemFramesLite</name>
@@ -78,6 +78,7 @@
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-legacy</artifactId>
             <version>4.22.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
`adventure-text-serializer-legacy` is already bundled in the paper jar (`paper-1.21.10-105.jar` at the time of writing), so no need to shade it. 

reduces jar size from 582 KB to 48 KB