### PR TITLE
docs: update config comments to remove notice about legacy formatting

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,8 +6,8 @@ items:
 
     # uncomment the below to assign lore text for the item
     #lore:
-    #  - line1
-    #  - line2
+    #  - <blue>Line 1</blue>
+    #  - <color:#FF5555>Line 2
 
   invisible_glow_item_frame:
     name: <!italic>Invisible Glow Item Frame

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,10 +1,7 @@
-# Legacy chat formatting has been deprecated.
-# Please use Adventure's MiniMessage formatting: https://docs.advntr.dev/minimessage/format
-
 # configuration of item metadata
 items:
   invisible_item_frame:
-    name: <!italic>Invisible Item Frame # what the name of the item should be
+    name: <!italic>Invisible Item Frame # use Adventure's MiniMessage formatting: https://docs.advntr.dev/minimessage/format
     enchantment_glint: true # if the item should have an enchantment glint
 
     # uncomment the below to assign lore text for the item


### PR DESCRIPTION
- remove line about legacy formatting being deprecated, this should no longer be applicable, 94.6% of servers have already migrated to v3. likely to cause more risk of confusion for new installs at this point
- add examples of adventure minimsg formatting