### PR TITLE
feat: add /invisframes give <regular|glow> to give an invisible item frame

### DIFF
--- a/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/InvisibleItemFramesLite.java
@@ -1,5 +1,6 @@
 package com.atlasgong.invisibleitemframeslite;
 
+import com.atlasgong.invisibleitemframeslite.command.InvisFramesCommand;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameBreakListener;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameCraftListener;
 import com.atlasgong.invisibleitemframeslite.listeners.ItemFrameInteractionListener;
@@ -14,6 +15,8 @@ import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.Objects;
 
 public class InvisibleItemFramesLite extends JavaPlugin {
 
@@ -85,6 +88,11 @@ public class InvisibleItemFramesLite extends JavaPlugin {
 
         // register shapeless glow item frame recipe
         registerShapelessGlowRecipe(getShapelessGlowRecipeKey());
+
+        // register commands
+        InvisFramesCommand command = new InvisFramesCommand();
+        Objects.requireNonNull(getCommand("invisframes")).setExecutor(command);
+        Objects.requireNonNull(getCommand("invisframes")).setTabCompleter(command);
 
         // incl metrics for bStats
         int pluginId = 25837;

--- a/src/main/java/com/atlasgong/invisibleitemframeslite/command/InvisFramesCommand.java
+++ b/src/main/java/com/atlasgong/invisibleitemframeslite/command/InvisFramesCommand.java
@@ -1,0 +1,127 @@
+package com.atlasgong.invisibleitemframeslite.command;
+
+import com.atlasgong.invisibleitemframeslite.ItemFrameRegistry;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Handles the /invisframes command.
+ * <p>
+ * This command allows players with the appropriate permission to receive
+ * invisible item frames via subcommands.
+ *
+ * <pre>
+ * Usage:
+ *   /invisframes give regular
+ *   /invisframes give glow
+ * </pre>
+ * <p>
+ * Tab-completion is provided for the "give" subcommand and its arguments.
+ */
+public class InvisFramesCommand implements CommandExecutor, TabCompleter {
+
+    /**
+     * Executes the /invisframes command.
+     *
+     * @param sender  the command sender
+     * @param command the command being executed
+     * @param label   the alias used to execute the command
+     * @param args    command arguments
+     * @return true if the command was handled
+     */
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender,
+                             @NotNull Command command,
+                             @NotNull String label,
+                             String[] args) {
+
+        // Ensure the command is executed by a player
+        if (!(sender instanceof Player player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+
+        // Handle "give" subcommand
+        if (args.length >= 2 && args[0].equalsIgnoreCase("give")) {
+            // Permission check
+            if (!player.hasPermission("invisibleitemframeslite.give")) {
+                sender.sendMessage("§cYou don't have permission to use this command.");
+                return true;
+            }
+
+            give(player, args[1]);
+        } else {
+            help(player);
+        }
+        return true;
+    }
+
+    /**
+     * Gives an invisible item frame to the player based on the specified type.
+     *
+     * @param player the player receiving the item frame
+     * @param type   the frame type ("regular" or "glow")
+     */
+    private void give(Player player, String type) {
+        ItemFrameRegistry registry = ItemFrameRegistry.getInstance();
+        ItemStack frame;
+
+        switch (type.toLowerCase()) {
+            case "regular" -> frame = registry.getRegularInvisibleFrame();
+            case "glow" -> frame = registry.getGlowInvisibleFrame();
+            default -> {
+                help(player);
+                return;
+            }
+        }
+
+        player.getInventory().addItem(frame);
+    }
+
+    /**
+     * Sends the command usage message to the player.
+     *
+     * @param player the player to send the help message to
+     */
+    private void help(Player player) {
+        player.sendMessage("§cUsage: /invisframes give <regular|glow>");
+    }
+
+    /**
+     * Provides tab-completion for the /invisframes command.
+     *
+     * @param sender  the command sender
+     * @param command the command being tab-completed
+     * @param alias   the alias used
+     * @param args    current command arguments
+     * @return a list of possible completions
+     */
+    @Override
+    public List<String> onTabComplete(@NotNull CommandSender sender,
+                                      @NotNull Command command,
+                                      @NotNull String alias,
+                                      String[] args) {
+
+        List<String> list = new ArrayList<>();
+
+        if (sender instanceof Player player) {
+            if (args.length == 1) {
+                if (player.hasPermission("invisibleitemframeslite.command.give")) {
+                    list.add("give");
+                }
+            } else if (args.length == 2 && args[0].equalsIgnoreCase("give") &&
+                    player.hasPermission("invisibleitemframeslite.command.give")) {
+                list = List.of("regular", "glow");
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,3 +6,14 @@ description: Adds craftable invisible item frames for survival.
 author: atlasgong
 contributors: [ Tiffnix ]
 website: "https://github.com/atlasgong/InvisibleItemFramesLite"
+
+commands:
+  invisframes:
+    description: Give invisible item frames
+    usage: /invisframes give <regular|glow>
+    permission: invisibleitemframeslite.give
+
+permissions:
+  invisibleitemframeslite.give:
+    description: Allows giving invisible item frames
+    default: op


### PR DESCRIPTION
I build on creative server, where it is much easier to use a simple command to obtain invisible item frames.
For this reason, I added a simple command that allows players to directly receive invisible item frames (regular or glow).

The command syntax matches the original plugin’s command, but is intentionally limited to a single subcommand `/invisframes give <regular|glow>`.
And I add one permission for survival player `invisibleitemframeslite.give`.